### PR TITLE
Oc/04 slitwheel

### DIFF
--- a/METIS/METIS.yaml
+++ b/METIS/METIS.yaml
@@ -1,5 +1,6 @@
 ---
 ### METIS
+
 object: instrument
 alias: INST
 name: METIS
@@ -15,6 +16,20 @@ effects:
     class: SurfaceList
     kwargs:
       filename: LIST_METIS_mirrors_cfo.dat
+
+  - name: slit_wheel
+    description: collection of field masks and slits
+    class: SlitWheel
+    kwargs:
+      slit_names:
+        - A
+        - B
+        - C
+        - D
+        - E
+      filename_format: MASK_slit_{}.dat
+      current_slit: "!OBS.slit"
+      include: "!OBS.slit"
 
 #  - name : metis_adc_residuals
 #    class : AtmosphericDispersionCorrection

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -1,73 +1,74 @@
 ---
 ### METIS LM IMAGING MODE
+
 object: instrument
 alias: INST
 name: METIS_IMG_LM
 description: base configuration for METIS
 
 properties:
-    pixel_scale: 0.00525         # arcsec / pixel
-    plate_scale: 0.291666666667  # arcsec / mm
+  pixel_scale: 0.00525         # arcsec / pixel
+  plate_scale: 0.291666666667  # arcsec / mm
 
 effects:
-    - name: metis_img_lm_mirror_list
-      description: list of extra mirrors needed for the LM IMG mode
-      class: SurfaceList
-      kwargs:
-          filename: LIST_METIS_mirrors_img_lm.dat
+  - name: metis_img_lm_mirror_list
+    description: list of extra mirrors needed for the LM IMG mode
+    class: SurfaceList
+    kwargs:
+      filename: LIST_METIS_mirrors_img_lm.dat
 
-    - name: filter_wheel
-      description: IMG_LM science filters
-      class: FilterWheel
-      kwargs:
-          filter_names:
-              # 18 positions (E-REP-MPIA-MET-1008_1-0)
-              - open
-              - Lp
-              - short-L
-              - L_spec
-              - Mp
-              - M_spec
-              - Br_alpha
-              - Br_alpha_ref
-              - PAH_3.3
-              - PAH_3.3_ref
-              - CO_1-0_ice
-              - CO_ref
-              - H2O-ice
-              - IB_4.05
-              - HCI_L_short
-              - HCI_L_long
-              - HCI_M
-          filename_format: "!INST.filter_file_format"
-          current_filter: "!OBS.filter_name"
-          minimum_throughput: !!float 0.
-          outer: 56                               # E-REP-MPIA-MET-1008_1-0
-          outer_unit: "mm"
+  - name: filter_wheel
+    description: IMG_LM science filters
+    class: FilterWheel
+    kwargs:
+      filter_names:
+        # 18 positions (E-REP-MPIA-MET-1008_1-0)
+        - open
+        - Lp
+        - short-L
+        - L_spec
+        - Mp
+        - M_spec
+        - Br_alpha
+        - Br_alpha_ref
+        - PAH_3.3
+        - PAH_3.3_ref
+        - CO_1-0_ice
+        - CO_ref
+        - H2O-ice
+        - IB_4.05
+        - HCI_L_short
+        - HCI_L_long
+        - HCI_M
+      filename_format: "!INST.filter_file_format"
+      current_filter: "!OBS.filter_name"
+      minimum_throughput: !!float 0.
+      outer: 56                               # E-REP-MPIA-MET-1008_1-0
+      outer_unit: "mm"
 
-    - name: nd_filter_wheel
-      class: FilterWheel
-      description: IMG_LM neutral density filters
-      kwargs:
-          filter_names:
-              # 11 positions (E-REP-MPIA-MET-1008_1-0)
-              # OD = optical density, transmissivity 10^{-OD}.
-              - open
-              - ND_OD1
-              - ND_OD2
-              - ND_OD3
-              - ND_OD4
-              - ND_OD5
-          filename_format: "!INST.filter_file_format"
-          current_filter: "!OBS.nd_filter_name"
-          minimum_throughput: !!float 0.
-          outer: 56                                # E-REP-MPIA-MET-1008_1-0
-          outer_unit: "mm"
+  - name: nd_filter_wheel
+    class: FilterWheel
+    description: IMG_LM neutral density filters
+    kwargs:
+      filter_names:
+        # 11 positions (E-REP-MPIA-MET-1008_1-0)
+        # OD = optical density, transmissivity 10^{-OD}.
+        - open
+        - ND_OD1
+        - ND_OD2
+        - ND_OD3
+        - ND_OD4
+        - ND_OD5
+      filename_format: "!INST.filter_file_format"
+      current_filter: "!OBS.nd_filter_name"
+      minimum_throughput: !!float 0.
+      outer: 56                                # E-REP-MPIA-MET-1008_1-0
+      outer_unit: "mm"
 
-    - name: metis_psf_img
-      description: field constant, wavelength dependent PSF for imaging mode
-      class: FieldConstantPSF
-      kwargs:
-          filename: PSF_SCAO_9mag_06seeing.fits
-          wave_key: "WAVELENG"
-          bkg_width: -1
+  - name: metis_psf_img
+    description: field constant, wavelength dependent PSF for imaging mode
+    class: FieldConstantPSF
+    kwargs:
+      filename: PSF_SCAO_9mag_06seeing.fits
+      wave_key: "WAVELENG"
+      bkg_width: -1

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -24,6 +24,7 @@ effects:
     kwargs:
       filename: "!OBS.trace_file"
       wave_colname: "wavelength"
+      dwave: 0.0005
       s_colname: "xi"
       col_number_start: 1
-      invalid_value: 0
+      #invalid_value: None

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -12,11 +12,6 @@ effects:
   #    kwargs:
   #      filename: LIST_METIS_mirrors_lss_lm.dat
   #
-  - name: spectroscopic_slit_aperture
-    description: slit mask definition
-    class: ApertureMask
-    kwargs:
-      filename: "!OBS.slit_file"
 
   - name: lss_spectral_traces
     description: list of spectral order trace geometry on the focal plane

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -36,6 +36,7 @@ mode_yamls:
     properties:
       filter_name: Lp
       nd_filter_name: open
+      slit: false
 
   - object: observation
     alias: OBS
@@ -47,6 +48,7 @@ mode_yamls:
     properties:
       filter_name: N2
       nd_filter_name: open
+      slit: false
 
   - object: observation
     alias: OBS
@@ -58,7 +60,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       trace_file: TRACE_LSS_L.fits
-      slit_file: MASK_slit_C.dat
+      slit: C
       filter_name: L_spec
       nd_filter_name: open
 
@@ -72,7 +74,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       trace_file: TRACE_LSS_M.fits
-      slit_file: MASK_slit_C.dat
+      slit: C
       filter_name: M_spec
       nd_filter_name: open
 
@@ -86,7 +88,7 @@ mode_yamls:
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
       trace_file: TRACE_LSS_N.fits
-      slit_file: MASK_slit_C.dat
+      slit: C
       filter_name: N_spec
       nd_filter_name: open
 
@@ -97,6 +99,8 @@ mode_yamls:
     yamls:
       - METIS_LMS.yaml
       - METIS_DET_IFU.yaml
+    properties:
+      slit: false
 
   - object: observation     # is this a separate mode from nominal LMS?
     alias: OBS
@@ -105,6 +109,8 @@ mode_yamls:
     yamls:
       - METIS_LMS_EXT.yaml
       - METIS_DET_IFU.yaml
+    properties:
+      slit: false
 
 ignore_effects:
   - armazones_atmo_dispersion
@@ -127,7 +133,7 @@ properties:
     wave_mid: 10.5
     wave_max: 18.0
 
-###---
+### ---
 #### default simulation parameters needed for a METIS simulation
 # object : atmosphere overrides
 # alias : ATMO

--- a/METIS/tests/test_metis.py
+++ b/METIS/tests/test_metis.py
@@ -1,5 +1,6 @@
 '''Basic unit tests for irdb/METIS'''
-# pylint: disable=R0201
+# pylint: disable=no-self-use, missing-class-docstring
+# pylint: disable=missing-function-docstring
 
 import os
 from glob import glob
@@ -23,16 +24,22 @@ scopesim.rc.__config__["!SIM.file.local_packages_path"] = PKGS_DIR
 
 class TestLoads:
     '''Test that irdb/METIS is loaded and an OpticalTrain is produced'''
-    def test_scopesim_loads_package(self):
-        '''Load the configuration from default.yaml. Modes other than
-        the default are not tested.'''
-        metis = scopesim.OpticalTrain("METIS")
+
+    @pytest.mark.parametrize("themode",
+                             ["img_lm", "img_n", "lss_l", "lss_m", "lss_n"])
+    def test_scopesim_loads_package(self, themode):
+        '''Load the configuration for all supported modes'''
+        cmd = scopesim.UserCommands(use_instrument="METIS",
+                                    set_modes=[themode])
+        assert isinstance(cmd, scopesim.UserCommands)
+
+        metis = scopesim.OpticalTrain(cmd)
         assert isinstance(metis, scopesim.OpticalTrain)
 
 
 YAML_LIST = glob(os.path.join(PKGS_DIR, "METIS/*.yaml"))
-@pytest.fixture(scope="class", params=YAML_LIST)
-def yaml_list(request):
+@pytest.fixture(name="yaml_list", scope="class", params=YAML_LIST)
+def fixture_yaml_list(request):
     return scopesim.commands.user_commands.load_yaml_dicts(request.param)
 
 class TestYAML:
@@ -53,8 +60,8 @@ class TestYAML:
 
 
 FILTER_LIST = glob(os.path.join(PKGS_DIR, "METIS/filters/TC_filter_*.dat"))
-@pytest.fixture(scope="class", params=FILTER_LIST)
-def filter_ter(request):
+@pytest.fixture(name="filter_ter", scope="class", params=FILTER_LIST)
+def fixture_filter_ter(request):
     return scopesim.effects.FilterCurve(filename=request.param)
 
 class TestFilters:
@@ -79,8 +86,8 @@ class TestFilters:
 
 
 QE_LIST = glob(os.path.join(PKGS_DIR, "METIS/QE_detector_*.dat"))
-@pytest.fixture(scope="class", params=QE_LIST)
-def qe_curve(request):
+@pytest.fixture(name="qe_curve", scope="class", params=QE_LIST)
+def fixture_qe_curve(request):
     return scopesim.effects.QuantumEfficiencyCurve(filename=request.param)
 
 class TestQuantumEfficiency:
@@ -105,8 +112,8 @@ class TestQuantumEfficiency:
 
 
 TER_LIST = glob(os.path.join(PKGS_DIR, "METIS/TER_*.dat"))
-@pytest.fixture(scope="class", params=TER_LIST)
-def ter_curve(request):
+@pytest.fixture(name="ter_curve", scope="class", params=TER_LIST)
+def fixture_ter_curve(request):
     return scopesim.effects.TERCurve(filename=request.param)
 
 class TestTERCurve:
@@ -131,8 +138,8 @@ class TestTERCurve:
 
 
 FPA_LIST = glob(os.path.join(PKGS_DIR, "METIS/FPA_*_layout.dat"))
-@pytest.fixture(scope="class", params=FPA_LIST)
-def det_list(request):
+@pytest.fixture(name="det_list", scope="class", params=FPA_LIST)
+def fixture_det_list(request):
     return scopesim.effects.DetectorList(filename=request.param)
 
 class TestFPALayout:
@@ -149,8 +156,8 @@ class TestFPALayout:
 
 #### linearity files are currently empty, hence tests xfail
 LIN_LIST = glob(os.path.join(PKGS_DIR, "METIS/FPA_linearity_*.dat"))
-@pytest.fixture(scope="class", params=LIN_LIST)
-def lin_curve(request):
+@pytest.fixture(name="lin_curve", scope="class", params=LIN_LIST)
+def fixture_lin_curve(request):
     return scopesim.effects.LinearityCurve(filename=request.param)
 
 class TestLinearityCurve:
@@ -166,8 +173,8 @@ class TestLinearityCurve:
 
 
 MASK_LIST = glob(os.path.join(PKGS_DIR, "METIS/MASK_slit_*.dat"))
-@pytest.fixture(scope="class", params=MASK_LIST)
-def slit_mask(request):
+@pytest.fixture(name="slit_mask", scope="class", params=MASK_LIST)
+def fixture_slit_mask(request):
     return scopesim.effects.ApertureMask(filename=request.param)
 
 class TestSlitMask:
@@ -188,8 +195,8 @@ class TestSlitMask:
 
 
 TRACE_LIST = glob(os.path.join(PKGS_DIR, "METIS/TRACE*.fits"))
-@pytest.fixture(scope="class", params=TRACE_LIST)
-def trace_list(request):
+@pytest.fixture(name="trace_list", scope="class", params=TRACE_LIST)
+def fixture_trace_list(request):
     return scopesim.effects.SpectralTraceList(filename=request.param)
 
 class TestTraceFile:


### PR DESCRIPTION
I could approve this myself, but maybe someone else wants to have a quick look. I have implemented SlitWheel in `METIS.yaml`, so it is accessible to imaging and spectroscopic modes. Whether it is included or not is controlled by `!OBS.slit`. By default, it is `false` in imaging modes and set to `C` (arbitrarily) in long-slit spectroscopic modes. 